### PR TITLE
added shifted date field into /getInstrumentReadyState to match the o…

### DIFF
--- a/src/api.tsx
+++ b/src/api.tsx
@@ -162,7 +162,7 @@ export function scheduleApi() {
             if (stateLabel === "TDA Ready" || stateLabel === "Scheduled") {
               try {
                 const readyRes = await fetch(
-                  `${urls.SCHEDULE_API}/getInstrumentReadyState?instrument=${encodeURIComponent(instrumentName)}`
+                  `${urls.SCHEDULE_API}/getInstrumentReadyState?instrument=${encodeURIComponent(instrumentName)}&date=${hstDate}`
                 );
                 if (readyRes.ok) {
                   const readyJson = await readyRes.json();


### PR DESCRIPTION
…ther schedule api calls

Added date value into the api call with the shifted HST date so it will use the previous day even during early morning observing.